### PR TITLE
chore(deps): Update objc2 to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,29 +58,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
 name = "block2"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58aa60e59d8dbfcc36138f5f18be5f24394d33b38b24f7fd0b1caa33095f22f"
-dependencies = [
- "block-sys",
- "objc2",
-]
-
-[[package]]
-name = "block2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
 dependencies = [
  "objc2",
 ]
@@ -154,16 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "icrate"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb69199826926eb864697bddd27f73d9fddcffc004f5733131e15b465e30642"
-dependencies = [
- "block2 0.4.0",
- "objc2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,96 +193,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
 name = "objc2"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
 dependencies = [
- "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
 dependencies = [
  "bitflags",
- "block2 0.5.1",
- "libc",
- "objc2",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-foundation",
- "objc2-quartz-core",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
-dependencies = [
- "bitflags",
- "block2 0.5.1",
  "objc2",
  "objc2-foundation",
 ]
 
 [[package]]
-name = "objc2-core-image"
-version = "0.2.2"
+name = "objc2-core-foundation"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
- "block2 0.5.1",
+ "bitflags",
  "objc2",
- "objc2-foundation",
- "objc2-metal",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
  "bitflags",
- "block2 0.5.1",
+ "block2",
  "libc",
  "objc2",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
-dependencies = [
- "bitflags",
- "block2 0.5.1",
- "objc2",
- "objc2-foundation",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "objc2-osa-kit"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6788b04a18ea31e3dc3ab256b8546639e5bbae07c1a0dc4ea8615252bc6aee9a"
+checksum = "a1ac59da3ceebc4a82179b35dc550431ad9458f9cc326e053f49ba371ce76c5a"
 dependencies = [
  "bitflags",
  "objc2",
@@ -320,24 +254,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-quartz-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
-dependencies = [
- "bitflags",
- "block2 0.5.1",
- "objc2",
- "objc2-foundation",
- "objc2-metal",
-]
-
-[[package]]
 name = "osakit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
- "icrate",
  "libtest-mimic-collect",
+ "objc2",
  "objc2-foundation",
  "objc2-osa-kit",
  "serde",
@@ -420,18 +341,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osakit"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Marat Dulin <mdevils@gmail.com>"]
 description = "OSAKit macOS Framework adapted for Rust"
@@ -17,12 +17,12 @@ categories = [
 ]
 
 [dependencies]
-icrate = { version = "0.1.0", features = ["OSAKit", "OSAKit_OSAScript", "Foundation_NSString", "OSAKit_OSALanguage", "Foundation_NSURL", "OSAKit_OSALanguageInstance", "Foundation_NSDictionary", "Foundation_NSAppleEventDescriptor", "Foundation_NSValue", "Foundation_NSNumber", "Foundation_NSNull", "Foundation_NSDate"] }
-objc2-foundation = { version = "0.2.2", features = ["NSAppleEventDescriptor", "NSArray", "NSDate", "NSDictionary", "NSEnumerator", "NSKeyValueCoding", "NSNull", "NSObject", "NSRange", "NSString", "NSValue"] }
-objc2-osa-kit = { version = "0.2.2", features = ["OSALanguage", "OSALanguageInstance", "OSAScript"] }
+objc2 = "0.6.0"
+objc2-foundation = { version = "0.3.0", features = ["NSAppleEventDescriptor", "NSArray", "NSDate", "NSDictionary", "NSEnumerator", "NSKeyValueCoding", "NSNull", "NSObject", "NSRange", "NSString", "NSValue"] }
+objc2-osa-kit = { version = "0.3.0", features = ["OSALanguage", "OSALanguageInstance", "OSAScript"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 
 [dev-dependencies]
 libtest-mimic-collect = "0.3.1"

--- a/src/export/value/input.rs
+++ b/src/export/value/input.rs
@@ -1,6 +1,5 @@
 use crate::Value;
-use icrate::objc2::rc::Id;
-use icrate::objc2::ClassType;
+use objc2::{rc::Retained, AllocAnyThread};
 use objc2_foundation::{NSArray, NSDictionary, NSNull, NSNumber, NSObject, NSString};
 use std::ops::Deref;
 use thiserror::Error;
@@ -11,12 +10,14 @@ pub enum ScriptInputConversionError {
     NumberConversionError(String),
 }
 
-fn value_to_nsobject(value: Value) -> Result<Id<NSObject>, ScriptInputConversionError> {
+fn value_to_nsobject(value: Value) -> Result<Retained<NSObject>, ScriptInputConversionError> {
     Ok(unsafe {
         match value {
-            Value::String(s) => Id::cast(NSString::from_str(&s)),
-            Value::Bool(b) => Id::cast(NSNumber::initWithBool(NSNumber::alloc(), b)),
-            Value::Number(n) => Id::cast(if n.is_f64() {
+            Value::String(s) => Retained::cast_unchecked(NSString::from_str(&s)),
+            Value::Bool(b) => {
+                Retained::cast_unchecked(NSNumber::initWithBool(NSNumber::alloc(), b))
+            }
+            Value::Number(n) => Retained::cast_unchecked(if n.is_f64() {
                 n.as_f64()
                     .map(|f| NSNumber::initWithDouble(NSNumber::alloc(), f))
                     .ok_or_else(|| {
@@ -35,17 +36,17 @@ fn value_to_nsobject(value: Value) -> Result<Id<NSObject>, ScriptInputConversion
                         ScriptInputConversionError::NumberConversionError(n.to_string())
                     })?
             }),
-            Value::Null => Id::cast(NSNull::null()),
-            Value::Array(vec) => Id::cast(values_vec_to_ns_array(vec)?),
+            Value::Null => Retained::cast_unchecked(NSNull::null()),
+            Value::Array(vec) => Retained::cast_unchecked(values_vec_to_ns_array(vec)?),
             Value::Object(obj) => {
-                let mut keys: Vec<Id<NSString>> = Vec::new();
-                let mut values: Vec<Id<NSObject>> = Vec::new();
+                let mut keys: Vec<Retained<NSString>> = Vec::new();
+                let mut values: Vec<Retained<NSObject>> = Vec::new();
                 for (key, value) in obj.into_iter() {
                     keys.push(NSString::from_str(&key));
                     values.push(value_to_nsobject(value)?)
                 }
                 let key_refs: Vec<&NSString> = keys.iter().map(|k| k.deref()).collect();
-                Id::cast(NSDictionary::from_vec(&key_refs, values))
+                Retained::cast_unchecked(NSDictionary::from_retained_objects(&key_refs, &values))
             }
         }
     })
@@ -53,12 +54,12 @@ fn value_to_nsobject(value: Value) -> Result<Id<NSObject>, ScriptInputConversion
 
 pub(crate) fn values_vec_to_ns_array<I: IntoIterator<Item = Value>>(
     values: I,
-) -> Result<Id<NSArray>, ScriptInputConversionError> {
-    let mut vec: Vec<Id<NSObject>> = Vec::new();
+) -> Result<Retained<NSArray>, ScriptInputConversionError> {
+    let mut vec: Vec<Retained<NSObject>> = Vec::new();
 
     for item in values {
         vec.push(value_to_nsobject(item)?);
     }
 
-    Ok(unsafe { Id::cast::<NSArray>(NSArray::from_vec(vec)) })
+    Ok(unsafe { Retained::cast_unchecked::<NSArray>(NSArray::from_retained_slice(&vec)) })
 }


### PR DESCRIPTION
Hello :) Your crate was the last one in our chain that was still pulling in older objc2 (and even older icrate deps) versions so i thought i'd open a small PR to fix that.

This PR updates the objc2 framework crates from 0.2 to 0.3 and replaces icrate with objc2 since the only use for icrate here was its objc2 re-export.

There were no logic changes (my objc knowledge isn't _that_ deep). Most notably, `cast()` was replaced with its (still panicking) equivalent `cast_unchecked()` instead of the non-panicking `downcast()` method.